### PR TITLE
count変数が環境によって動かない問題を修正

### DIFF
--- a/GET/Like.php
+++ b/GET/Like.php
@@ -36,6 +36,7 @@ class Like extends ACMS_GET
         $SQL = SQL::newSelect('like');
         $SQL->addSelect('like_category');
         $SQL->addSelect('COUNT(`like_category`)');
+        $SQL->addSelect('like_category', 'amount', null, 'COUNT');
         $SQL->addWhereOpr('like_eid', $eid, '=');
         $SQL->addGroup('like_category');
         $all = $DB->query($SQL->get(dsn()), 'all');
@@ -43,9 +44,10 @@ class Like extends ACMS_GET
         // テンプレートに格納
         $count = [];
         foreach ($all as $key => $value) {
-            $count[$value['like_category']] = $value["COUNT(`like_category`)"];
-            if ($key == 'good') {
-                $count['count'] = $value["COUNT(`like_category`)"];
+            $key = $value['like_category'];
+            $count[$key] = $value['amount'];
+            if ($key === 'good') {
+                $count['count'] = $value['amount'];
             }
         }
 


### PR DESCRIPTION
いつもお世話になっております。
環境によって動いていない箇所を発見いたしましたので、プルリクさせていただきます...！🙏

Ver.2.11のphp5.6の環境では現状のままでも正常に動作したのですが、
Ver.3.0のphp8.0の環境ではcount変数が動作しませんでした。
（直接の原因がわかっておらず、もしかしたら別の要因かもしれませんが...）

こちらのコードに差し替えたところ、問題のあった環境でも正常に動作しました。
ご確認のほど、どうぞよろしくお願いいたします！

